### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Hex.pm](https://img.shields.io/hexpm/v/jellyfish_server_sdk.svg)](https://hex.pm/packages/jellyfish_server_sdk)
 [![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/jellyfish_server_sdk/)
-[![codecov](https://codecov.io/gh/jellyfish-dev/server_sdk_elixir/branch/master/graph/badge.svg?token=ByIko4o5U8)](https://codecov.io/gh/jellyfish-dev/server_sdk_elixir)
-[![CircleCI](https://circleci.com/gh/jellyfish-dev/server_sdk_elixir.svg?style=svg)](https://circleci.com/gh/jellyfish-dev/server_sdk_elixir)
+[![codecov](https://codecov.io/gh/jellyfish-dev/elixir_server_sdk/branch/master/graph/badge.svg?token=ByIko4o5U8)](https://codecov.io/gh/jellyfish-dev/elixir_server_sdk)
+[![CircleCI](https://circleci.com/gh/jellyfish-dev/elixir_server_sdk.svg?style=svg)](https://circleci.com/gh/jellyfish-dev/elixir_server_sdk)
 
 Elixir server SDK for [Jellyfish](https://github.com/jellyfish-dev/jellyfish).
 Currently it allows for:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package can be installed by adding `jellyfish_server_sdk` to your list of de
 ```elixir
 def deps do
   [
-    {:jellyfish_server_sdk, "~> 0.1.0"}
+    {:jellyfish_server_sdk, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/jellyfish/client.ex
+++ b/lib/jellyfish/client.ex
@@ -32,11 +32,11 @@ defmodule Jellyfish.Client do
   ## Parameters
 
     * `address` - url or IP address of the Jellyfish server instance
-    * `token` - token used for authorizing HTTP requests. It's the same
+    * `server_api_token` - token used for authorizing HTTP requests. It's the same
     token as the one configured in Jellyfish.
   """
   @spec new(String.t(), String.t()) :: t()
-  def new(address, token), do: build_client(address, token)
+  def new(address, server_api_token), do: build_client(address, server_api_token)
 
   @doc """
   Creates new instance of `t:Jellyfish.Client.t/0`.
@@ -44,7 +44,7 @@ defmodule Jellyfish.Client do
   Uses token set in `config.exs`. To explicitly pass the token, see `new/2`.
   ```
   # in config.exs
-  config :jellyfish_server_sdk, token: "your-jellyfish-token"
+  config :jellyfish_server_sdk, server_api_token: "your-jellyfish-token"
 
   client = Jellyfish.Client.new("http://address-of-your-server.com")
   ```
@@ -53,14 +53,14 @@ defmodule Jellyfish.Client do
   """
   @spec new(String.t()) :: t()
   def new(address) do
-    token = Application.fetch_env!(:jellyfish_server_sdk, :token)
-    build_client(address, token)
+    server_api_token = Application.fetch_env!(:jellyfish_server_sdk, :server_api_token)
+    build_client(address, server_api_token)
   end
 
-  defp build_client(address, token) do
+  defp build_client(address, server_api_token) do
     middleware = [
       {Tesla.Middleware.BaseUrl, address},
-      {Tesla.Middleware.BearerAuth, token: token},
+      {Tesla.Middleware.BearerAuth, token: server_api_token},
       Tesla.Middleware.JSON
     ]
 

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -13,7 +13,7 @@ defmodule Jellyfish.Room do
       peers: []
   }}
 
-  iex> {:ok, peer, token} = Jellyfish.Room.add_peer(client, room.id, "webrtc")
+  iex> {:ok, peer, peer_token} = Jellyfish.Room.add_peer(client, room.id, "webrtc")
    {:ok,
     %Jellyfish.Peer{id: "5a731f2e-f49f-4d58-8f64-16a5c09b520e", type: "webrtc"},
     "3LTQ3ZDEtYTRjNy0yZDQyZjU1MDAxY2FkAAdyb29tX2lkbQAAACQ0M"}
@@ -41,7 +41,7 @@ defmodule Jellyfish.Room do
   @type id :: String.t()
 
   @typedoc """
-  Client token, created by Jellyfish. Required by client application to open connection to Jellyfish.
+  Peer token, created by Jellyfish. Required by client application to open connection to Jellyfish.
   """
   @type peer_token :: String.t()
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Template.Mixfile do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @github_url "https://github.com/jellyfish-dev/server_sdk_elixir"
   @homepage_url "https://membrane.stream"
 
@@ -9,7 +9,7 @@ defmodule Membrane.Template.Mixfile do
     [
       app: :jellyfish_server_sdk,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Membrane.Template.Mixfile do
   use Mix.Project
 
   @version "0.1.1"
-  @github_url "https://github.com/jellyfish-dev/server_sdk_elixir"
+  @github_url "https://github.com/jellyfish-dev/elixir_server_sdk"
   @homepage_url "https://membrane.stream"
 
   def project do

--- a/test/jellyfish/client_test.exs
+++ b/test/jellyfish/client_test.exs
@@ -7,15 +7,15 @@ defmodule Jellyfish.ClientTest do
 
   describe "sdk" do
     test "creates client struct" do
-      token = "mock_token"
-      client = Client.new(@url, token)
+      server_api_token = "mock_token"
+      client = Client.new(@url, server_api_token)
 
       assert %Client{
                http_client: %Tesla.Client{
                  adapter: {Tesla.Adapter.Mint, :call, [[]]},
                  pre: [
                    {Tesla.Middleware.BaseUrl, :call, [@url]},
-                   {Tesla.Middleware.BearerAuth, :call, [[token: ^token]]},
+                   {Tesla.Middleware.BearerAuth, :call, [[token: ^server_api_token]]},
                    {Tesla.Middleware.JSON, :call, [[]]}
                  ]
                }

--- a/test/jellyfish/room_test.exs
+++ b/test/jellyfish/room_test.exs
@@ -5,7 +5,7 @@ defmodule Jellyfish.RoomTest do
 
   alias Jellyfish.{Client, Component, Peer, Room}
 
-  @token "testtoken"
+  @server_api_token "testtoken"
 
   @url "http://mockurl.com"
   @invalid_url "http://invalid-url.com"
@@ -43,7 +43,7 @@ defmodule Jellyfish.RoomTest do
       end
     end)
 
-    %{client: Client.new(@url, @token)}
+    %{client: Client.new(@url, @server_api_token)}
   end
 
   describe "auth" do
@@ -56,7 +56,7 @@ defmodule Jellyfish.RoomTest do
                 body: ^valid_body
               } = env ->
         case Tesla.get_header(env, "authorization") do
-          "Bearer " <> @token ->
+          "Bearer " <> @server_api_token ->
             json(%{"data" => build_room_json(true)}, status: 201)
 
           "Bearer " <> _other ->
@@ -71,7 +71,7 @@ defmodule Jellyfish.RoomTest do
     end
 
     test "invalid token" do
-      client = Client.new(@url, "invalid" <> @token)
+      client = Client.new(@url, "invalid" <> @server_api_token)
       assert {:error, _reason} = Room.create(client, max_peers: @max_peers)
     end
   end
@@ -283,7 +283,7 @@ defmodule Jellyfish.RoomTest do
     end
 
     test "when request is valid", %{client: client} do
-      assert {:ok, peer, _token} = Room.add_peer(client, @room_id, @peer_type)
+      assert {:ok, peer, _peer_token} = Room.add_peer(client, @room_id, @peer_type)
       assert peer == build_peer()
     end
 


### PR DESCRIPTION
I've made a horrible mistake of releasing this package after PR with initial implementation, so
now, to avoid confusion (why initial version of Jellyfish should use v0.2.0 of server SDK?) me and @mickel8 decided to release it under v0.1.1 instead of new minor, but I'm not entirely sure about that.